### PR TITLE
Use `array()` to be PHP5.3 compatible

### DIFF
--- a/src/Elgentos/Magento/Command/Dev/TemplateVars.php
+++ b/src/Elgentos/Magento/Command/Dev/TemplateVars.php
@@ -56,7 +56,7 @@ class TemplateVars extends AbstractMagentoCommand
 
             $sql = "SELECT %s FROM %s WHERE %s LIKE '%%{{config %%' OR  %s LIKE '%%{{block %%'";
 
-            $list = ['block' => [], 'variable' => []];
+            $list = array('block' => array(), 'variable' => array());
             $cmsCheck = sprintf($sql, 'content', $cmsBlockTable, 'content', 'content');
             $result = $db->fetchAll($cmsCheck);
             $this->check($result, 'content', $list);
@@ -106,7 +106,7 @@ class TemplateVars extends AbstractMagentoCommand
                 if(is_dir($path . DS . $subdir)) {
                     $this->walkDir(scandir($path . DS . $subdir), $path . DS . $subdir, $list);
                 } elseif (is_file($path . DS . $subdir) && pathinfo($subdir, PATHINFO_EXTENSION) !== 'csv') {
-                    $this->check([file_get_contents($path . DS . $subdir)], null, $list);
+                    $this->check(array(file_get_contents($path . DS . $subdir)), null, $list);
                 }
             }
         }


### PR DESCRIPTION
The new array syntax is only available in PHP5.4 and above, however we have Ubuntu 12.04 hosts which are running with PHP5.3, so need to use the old syntax. I think this is the only place in the module where the newer syntax is used.