### PR TITLE
Fix pcntl_signal for older php versions

### DIFF
--- a/src/Elgentos/Magento/Command/Dev/Events/ListenCommand.php
+++ b/src/Elgentos/Magento/Command/Dev/Events/ListenCommand.php
@@ -30,8 +30,8 @@ class ListenCommand extends AbstractMagentoCommand
 
         $this->output = $output;
 
-        pcntl_signal(SIGTERM, [$this, 'stopCommand']);
-        pcntl_signal(SIGINT, [$this, 'stopCommand']);
+        pcntl_signal(SIGTERM, array($this, 'stopCommand'));
+        pcntl_signal(SIGINT, array($this, 'stopCommand'));
 
         $this->detectMagento($output);
         if ($this->initMagento()) {


### PR DESCRIPTION
the callback handle does not work on PHP 5.3, therefore this fix is needed