### PR TITLE
Added modman-file and magento composer installer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "mothership/magerun-addons",
   "description": "Addon commands for N98 MageRun",
+  "type": "magento-module",
   "keywords": [
     "magerun"
   ],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "mothership/magerun-addons",
+  "name": "peterjaap/magerun-addons",
   "description": "Addon commands for N98 MageRun",
   "type": "magento-module",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,27 @@
 {
-    "name": "peterjaap/magerun-addons",
-    "type": "library",
-    "description": "Addon commands for N98 MageRun",
-    "keywords": ["magerun"],
-    "homepage": "https://github.com/peterjaap/magerun-addons",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Peter Jaap Blaakmeer",
-            "email": "peterjaap@elgentos.nl",
-            "homepage": "http://www.elgentos.nl",
-            "role": "Developer"
-        }
-    ],
-    "require": {
-        "php": ">=5.3.0"
-    },
-    "autoload": {
-        "psr-0": {
-            "Elgentos": "src/"
-        }
+  "name": "peterjaap/magerun-addons",
+  "type": "library",
+  "description": "Addon commands for N98 MageRun",
+  "keywords": [
+    "magerun"
+  ],
+  "homepage": "https://github.com/peterjaap/magerun-addons",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Peter Jaap Blaakmeer",
+      "email": "peterjaap@elgentos.nl",
+      "homepage": "http://www.elgentos.nl",
+      "role": "Developer"
     }
+  ],
+  "require": {
+    "php": ">=5.3",
+    "magento-hackathon/magento-composer-installer": "*"
+  },
+  "autoload": {
+    "psr-0": {
+      "Elgentos": "src/"
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "mothership/magerun-addons",
-  "type": "library",
   "description": "Addon commands for N98 MageRun",
   "keywords": [
     "magerun"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "peterjaap/magerun-addons",
+  "name": "mothership/magerun-addons",
   "type": "library",
   "description": "Addon commands for N98 MageRun",
   "keywords": [

--- a/modman
+++ b/modman
@@ -1,0 +1,1 @@
+src/Elgentos                   lib/n98-magerun/modules/Elgentos

--- a/modman
+++ b/modman
@@ -1,1 +1,1 @@
-src/Elgentos                   lib/n98-magerun/modules/Elgentos
+.                   lib/n98-magerun/modules/Elgentos


### PR DESCRIPTION
I have added a modman file and updated the composer file, so that it includes the Magento composer installer. This will enable the module to automatically install into the .modman directory when set as a dependency in your local composer file.

Example:

```
{
  "minimum-stability": "dev",
  "require": {
    "peterjaap/magerun-addons": "dev-master"
  },
  "config": {
    "bin-dir": "bin"
  },
  "repositories": [
    {
      "type": "composer",
      "url": "http://packages.firegento.com"
    }
  ]
}
```

This will install the extension in the ```.modman``` instead of the ```vendor``` directory. Therefore only a ```modman deploy magerun-addons``` is needed. 