### PR TITLE
[fix] Add magento table_prefix on media:images commands

### DIFF
--- a/src/Elgentos/Magento/Command/Media/Images/CleanTablesCommand.php
+++ b/src/Elgentos/Magento/Command/Media/Images/CleanTablesCommand.php
@@ -30,6 +30,7 @@ class CleanTablesCommand extends AbstractMagentoCommand
             $thumbnailAttrId = $eavAttribute->getIdByCode('catalog_product', 'thumbnail');
             $smallImageAttrId = $eavAttribute->getIdByCode('catalog_product', 'small_image');
             $imageAttrId = $eavAttribute->getIdByCode('catalog_product', 'image');
+            $prefix_table = \Mage::getConfig()->getTablePrefix();
 
             $dialog = $this->getHelperSet()->get('dialog');
 
@@ -48,13 +49,13 @@ class CleanTablesCommand extends AbstractMagentoCommand
 
             if ($cleanUpTableRowsMediaGallery) {
                 /* Clean up images from media gallery tables */
-                $images = $db->fetchAll('SELECT value,value_id FROM catalog_product_entity_media_gallery');
+                $images = $db->fetchAll('SELECT value,value_id FROM '.$prefix_table.'catalog_product_entity_media_gallery');
                 foreach ($images as $image) {
                     if (!file_exists(\Mage::getBaseDir('media') . DS . 'catalog' . DS . 'product' . $image['value'])) {
                         $output->writeln($image['value'] . ' does not exist on disk; deleting row from database.');
                         if(!$dryRun) {
-                            $db->query('DELETE FROM catalog_product_entity_media_gallery WHERE value_id = ?', $image['value_id']);
-                            $db->query('DELETE FROM catalog_product_entity_media_gallery_value WHERE value_id = ?', $image['value_id']);
+                            $db->query('DELETE FROM '.$prefix_table.'catalog_product_entity_media_gallery WHERE value_id = ?', $image['value_id']);
+                            $db->query('DELETE FROM '.$prefix_table.'catalog_product_entity_media_gallery_value WHERE value_id = ?', $image['value_id']);
                         }
                     }
                 }
@@ -62,12 +63,12 @@ class CleanTablesCommand extends AbstractMagentoCommand
 
             if ($cleanUpTableRowsVarchar) {
                 /* Clean up images from varchar table */
-                $images = $db->fetchAll('SELECT value,value_id FROM catalog_product_entity_varchar WHERE attribute_id = ? OR attribute_id = ? OR attribute_id = ?', array($thumbnailAttrId, $smallImageAttrId, $imageAttrId));
+                $images = $db->fetchAll('SELECT value,value_id FROM '.$prefix_table.'catalog_product_entity_varchar WHERE attribute_id = ? OR attribute_id = ? OR attribute_id = ?', array($thumbnailAttrId, $smallImageAttrId, $imageAttrId));
                 foreach ($images as $image) {
                     if (!file_exists(\Mage::getBaseDir('media') . DS . 'catalog' . DS . 'product' . $image['value'])) {
                         $output->writeln($image['value'] . ' does not exist on disk; deleting row from database.');
                         if(!$dryRun) {
-                            $db->query('DELETE FROM catalog_product_entity_varchar WHERE value_id = ?',  $image['value_id']);
+                            $db->query('DELETE FROM '.$prefix_table.'catalog_product_entity_varchar WHERE value_id = ?',  $image['value_id']);
                         }
                     }
                 }

--- a/src/Elgentos/Magento/Command/Media/Images/DefaultImageCommand.php
+++ b/src/Elgentos/Magento/Command/Media/Images/DefaultImageCommand.php
@@ -31,6 +31,7 @@ class DefaultImageCommand extends AbstractMagentoCommand
             $smallImageAttrId = $eavAttribute->getIdByCode('catalog_product', 'small_image');
             $imageAttrId = $eavAttribute->getIdByCode('catalog_product', 'image');
             $mediaGalleryAttributeId = $eavAttribute->getIdByCode('catalog_product', 'media_gallery');
+            $prefix_table = \Mage::getConfig()->getTablePrefix();
 
             $dialog = $this->getHelperSet()->get('dialog');
 
@@ -40,10 +41,10 @@ class DefaultImageCommand extends AbstractMagentoCommand
             $dryRun = $dialog->askConfirmation($output,
                 '<question>Dry run?</question> <comment>[no]</comment> ', false);
 
-            $products = $db->fetchAll('SELECT sku,entity_id FROM catalog_product_entity');
+            $products = $db->fetchAll('SELECT sku,entity_id FROM '.$prefix_table.'catalog_product_entity');
             foreach ($products as $product) {
                 $chooseDefaultImage = false;
-                $images = $db->fetchAll('select * from catalog_product_entity_varchar where `entity_id` = ? AND (`attribute_id` = ? OR `attribute_id` = ? OR `attribute_id` = ?)',
+                $images = $db->fetchAll('select * from '.$prefix_table.'catalog_product_entity_varchar where `entity_id` = ? AND (`attribute_id` = ? OR `attribute_id` = ? OR `attribute_id` = ?)',
                     array($product['entity_id'], $imageAttrId, $smallImageAttrId, $thumbnailAttrId));
                 if (count($images) == 0) {
                     $chooseDefaultImage = true;
@@ -56,13 +57,13 @@ class DefaultImageCommand extends AbstractMagentoCommand
                     }
                 }
                 if ($chooseDefaultImage) {
-                    $defaultImage = $db->fetchOne('SELECT value FROM catalog_product_entity_media_gallery WHERE entity_id = ? AND attribute_id = ? LIMIT 1', array($product['entity_id'], $mediaGalleryAttributeId));
+                    $defaultImage = $db->fetchOne('SELECT value FROM '.$prefix_table.'catalog_product_entity_media_gallery WHERE entity_id = ? AND attribute_id = ? LIMIT 1', array($product['entity_id'], $mediaGalleryAttributeId));
                     if ($defaultImage && !$dryRun) {
-                        $db->query('INSERT INTO catalog_product_entity_varchar SET entity_type_id = ?, attribute_id = ?, store_id = ?, entity_id = ?, value = ? ON DUPLICATE KEY UPDATE value = ?',
+                        $db->query('INSERT INTO '.$prefix_table.'catalog_product_entity_varchar SET entity_type_id = ?, attribute_id = ?, store_id = ?, entity_id = ?, value = ? ON DUPLICATE KEY UPDATE value = ?',
                             array(4, $imageAttrId, 0, $product['entity_id'], $defaultImage, $defaultImage));
-                        $db->query('INSERT INTO catalog_product_entity_varchar SET entity_type_id = ?, attribute_id = ?, store_id = ?, entity_id = ?, value = ? ON DUPLICATE KEY UPDATE value = ?',
+                        $db->query('INSERT INTO '.$prefix_table.'catalog_product_entity_varchar SET entity_type_id = ?, attribute_id = ?, store_id = ?, entity_id = ?, value = ? ON DUPLICATE KEY UPDATE value = ?',
                             array(4, $smallImageAttrId, 0, $product['entity_id'], $defaultImage, $defaultImage));
-                        $db->query('INSERT INTO catalog_product_entity_varchar SET entity_type_id = ?, attribute_id = ?, store_id = ?, entity_id = ?, value = ? ON DUPLICATE KEY UPDATE value = ?',
+                        $db->query('INSERT INTO '.$prefix_table.'catalog_product_entity_varchar SET entity_type_id = ?, attribute_id = ?, store_id = ?, entity_id = ?, value = ? ON DUPLICATE KEY UPDATE value = ?',
                             array(4, $thumbnailAttrId, 0, $product['entity_id'], $defaultImage, $defaultImage));
 			$output->writeln('New default image has been set for ' . $product['sku']);
                     } elseif($defaultImage) {

--- a/src/Elgentos/Magento/Command/Media/Images/RemoveDuplicatesCommand.php
+++ b/src/Elgentos/Magento/Command/Media/Images/RemoveDuplicatesCommand.php
@@ -30,6 +30,7 @@ class RemoveDuplicatesCommand extends AbstractMagentoCommand
 
             $resource = \Mage::getModel('core/resource');
             $db = $resource->getConnection('core_write');
+            $prefix_table = \Mage::getConfig()->getTablePrefix();
 
             $dryRun = $dialog->askConfirmation($output,
                 '<question>Dry run?</question> <comment>[no]</comment> ', false);
@@ -61,10 +62,10 @@ class RemoveDuplicatesCommand extends AbstractMagentoCommand
                     if (file_exists($newFileOnServer) && file_exists($oldFileOnServer)) {
                         if(!$dryRun) {
                             $db->beginTransaction();
-                            $resultVarchar = $db->update('catalog_product_entity_varchar', array('value' => $original), $db->quoteInto('value =?', $file));
+                            $resultVarchar = $db->update($prefix_table.'catalog_product_entity_varchar', array('value' => $original), $db->quoteInto('value =?', $file));
                             $db->commit();
                             $db->beginTransaction();
-                            $resultGallery = $db->update('catalog_product_entity_media_gallery', array('value' => $original), $db->quoteInto('value =?', $file));
+                            $resultGallery = $db->update($prefix_table.'catalog_product_entity_media_gallery', array('value' => $original), $db->quoteInto('value =?', $file));
                             $db->commit();
                         } else {
                             $resultVarchar = ':unknown_in_dry_run:';

--- a/src/Elgentos/Magento/Command/Media/Images/RemoveOrphansCommand.php
+++ b/src/Elgentos/Magento/Command/Media/Images/RemoveOrphansCommand.php
@@ -36,13 +36,15 @@ class RemoveOrphansCommand extends AbstractMagentoCommand
 
             $dir = \Mage::getBaseDir('media') . DS . 'catalog' . DS . 'product';
             $files = glob($dir . DS . '[A-z0-9]' . DS . '[A-z0-9]' . DS . '*');
+            $prefix_table = \Mage::getConfig()->getTablePrefix();
             $total = $deleted = 0;
             foreach ($files as $file) {
                 if (!is_file($file)) {
                     continue;
                 }
                 $filename = DS . implode(DS, array_slice(explode(DS, $file), -3));
-                $results = $db->fetchAll('SELECT * FROM catalog_product_entity_media_gallery WHERE value = ?', $filename);
+
+                $results = $db->fetchAll('SELECT * FROM '.$prefix_table.'catalog_product_entity_media_gallery WHERE value = ?', $filename);
                 if (count($results) == 0) {
                     if(!$dryRun) {
                         unlink($file);


### PR DESCRIPTION
media:images do not have magento table prefix.
This is a little fix.