### PR TITLE
Matt jamersan patch 1

### DIFF
--- a/src/Elgentos/Magento/Command/Dev/OldAdminRouting.php
+++ b/src/Elgentos/Magento/Command/Dev/OldAdminRouting.php
@@ -42,6 +42,7 @@ class OldAdminRouting extends AbstractMagentoCommand
                 foreach($offendingExtensions as $extension) {
                     $output->writeln($extension);
                 }
+                $output->writeln("\033[0m");
             } else {
                 $output->writeln("\033[1;32mYay! All extension are compatible, good job!\033[0m");
             }

--- a/src/Elgentos/Magento/Command/Dev/TemplateVars.php
+++ b/src/Elgentos/Magento/Command/Dev/TemplateVars.php
@@ -103,7 +103,7 @@ class TemplateVars extends AbstractMagentoCommand
                         $output->writeln("\033[1;33mWhitelisted " . $blockName . ".\033[1;33m");
                     }
                 }
-                $output->writeln('');
+                $output->writeln("\033[0m");
             }
             if (count($nonWhitelistedVars) > 0) {
                 $output->writeln("\033[0;31mFound template/block variables that are not whitelisted by default;\033[0;31m");
@@ -118,6 +118,7 @@ class TemplateVars extends AbstractMagentoCommand
             if (count($nonWhitelistedBlocks) == 0 && count($nonWhitelistedVars) == 0) {
                 $output->writeln("\033[1;32mYay! All blocks and variables are whitelisted.\033[0m");
             }
+            $output->writeln("\033[0m");
         }
     }
 


### PR DESCRIPTION
in terminal these two functions have a red output that persists after the function exits. I'm trying to remedy this by ending the color with a separate 'writeln()' call