### PR TITLE
Perform case-sensitive matching in database

### DIFF
--- a/src/Elgentos/Magento/Command/Media/Images/RemoveOrphansCommand.php
+++ b/src/Elgentos/Magento/Command/Media/Images/RemoveOrphansCommand.php
@@ -44,14 +44,15 @@ class RemoveOrphansCommand extends AbstractMagentoCommand
                 }
                 $filename = DS . implode(DS, array_slice(explode(DS, $file), -3));
 
-                $results = $db->fetchAll('SELECT * FROM '.$prefix_table.'catalog_product_entity_media_gallery WHERE value = ?', $filename);
-                if (count($results) == 0) {
+                $count = $db->query('SELECT COUNT(*) FROM '.$prefix_table.'catalog_product_entity_media_gallery WHERE BINARY value = ?', $filename)->fetchColumn();
+                if ($count == 0) {
                     if(!$dryRun) {
                         unlink($file);
                         if (!file_exists($file)) {
                             $output->writeln($file . ' has been deleted.');
                         } else {
-                            die($file . ' still exists; no write permissions?');
+                            $output->writeln($file . ' still exists; no write permissions?');
+                            exit;
                         }
                     } else {
                         $output->writeln($file . ' would be deleted.');


### PR DESCRIPTION
The `removeorphans` command fails to delete files that are a case-insensitive match to an entry in the database. Since Magento only officially supports Linux as an OS, we can be confident that a file that doesn't match exactly to what's in the database is indeed an orphan.

Also:
* Changed the query to be ever so slightly more efficient with a `SELECT COUNT(*)` since that's all we need.
* Cleaned up error message for case when a file can't be deleted.