### PR TITLE
use GlobIterator instead of glob-function

### DIFF
--- a/src/Elgentos/Magento/Command/Media/Images/RemoveOrphansCommand.php
+++ b/src/Elgentos/Magento/Command/Media/Images/RemoveOrphansCommand.php
@@ -35,27 +35,30 @@ class RemoveOrphansCommand extends AbstractMagentoCommand
                 '<question>Dry run?</question> <comment>[no]</comment> ', false);
 
             $dir = \Mage::getBaseDir('media') . DS . 'catalog' . DS . 'product';
-            $files = glob($dir . DS . '[A-z0-9]' . DS . '[A-z0-9]' . DS . '*');
+            $globIterator = new \GlobIterator($dir . DS . '[A-z0-9]' . DS . '[A-z0-9]' . DS . '*');
+
             $prefix_table = \Mage::getConfig()->getTablePrefix();
             $total = $deleted = 0;
-            foreach ($files as $file) {
-                if (!is_file($file)) {
+
+            foreach ($globIterator as $fileInfo) {
+                if (!$fileInfo->isFile()) {
                     continue;
                 }
-                $filename = DS . implode(DS, array_slice(explode(DS, $file), -3));
+                $filename = DS . implode(DS, array_slice(explode(DS, $fileInfo->getPathname()), -3));
 
-                $count = $db->query('SELECT COUNT(*) FROM '.$prefix_table.'catalog_product_entity_media_gallery WHERE BINARY value = ?', $filename)->fetchColumn();
-                if ($count == 0) {
-                    if(!$dryRun) {
-                        unlink($file);
-                        if (!file_exists($file)) {
-                            $output->writeln($file . ' has been deleted.');
+                $count = (int)$db->query('SELECT COUNT(*) FROM ' . $prefix_table . 'catalog_product_entity_media_gallery WHERE BINARY value = ?',
+                    $filename)->fetchColumn();
+                if ($count === 0) {
+                    if (!$dryRun) {
+                        unlink($fileInfo->getPathname());
+                        if (!file_exists($fileInfo->getPathname())) {
+                            $output->writeln($fileInfo->getPathname() . ' has been deleted.');
                         } else {
-                            $output->writeln($file . ' still exists; no write permissions?');
+                            $output->writeln($fileInfo->getPathname() . ' still exists; no write permissions?');
                             exit;
                         }
                     } else {
-                        $output->writeln($file . ' would be deleted.');
+                        $output->writeln($fileInfo->getPathname() . ' would be deleted.');
                     }
 
                     $deleted++;


### PR DESCRIPTION
I ran into memory-limit issues using "media:images:removeorphans".
I had about 200GB of media files (actually 198GB orphaned files) - I didn't count the amount of files.
The usual workaround "php -dmemory_limit=-1 -f n98magerun.phar media:images:removeorphans" did not help.
So I decided to use SPL to get around this issue.