### PR TITLE
Use all media_gallery attributes for orphan check.

### DIFF
--- a/src/Elgentos/Magento/Command/Media/Images/AbstractCommand.php
+++ b/src/Elgentos/Magento/Command/Media/Images/AbstractCommand.php
@@ -154,7 +154,7 @@ class AbstractCommand extends AbstractMagentoCommand
         $select = $connection->select()
                 ->from(['v' => $varcharTable], ['value_id', 'value'])
                 ->join(['a' => $resource->getTableName('eav/attribute')], 'v.attribute_id = a.attribute_id', [])
-                ->where('a.attribute_code in(?)', ['image', 'small_image', 'thumbnail']);
+                ->where('a.frontend_input = ?', 'media_gallery');
 
         $values = [];
         $result = $connection->query($select);


### PR DESCRIPTION
Previously the attributes checked where hard-coded as the 3 that come
with core, 'image', 'small_image' and 'thumbnail'. By checking based on
the frontend_input property we also account for custom attributes added
to a product. This could have resulted in removal of images that weren't
trully orphans.